### PR TITLE
bug fix: when more than one environment variables is passed only last one is used

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -21,7 +21,8 @@ const createClient = (server: ServerConfig): { client: Client | undefined, trans
       transport = new StdioClientTransport({
         command: server.transport.command,
         args: server.transport.args,
-        env: server.transport.env ? server.transport.env.reduce((o, v) => ({
+        env: server.transport.env ? server.transport.env.reduce((acc, v) => ({
+          ...acc,
           [v]: process.env[v] || ''
         }), {}) : undefined
       });

--- a/src/config.ts
+++ b/src/config.ts
@@ -26,7 +26,11 @@ export interface Config {
 
 export const loadConfig = async (): Promise<Config> => {
   try {
-    const configPath = resolve(process.cwd(), 'config.json');
+    let configPath = process.env.MCP_CONFIG_PATH;
+    if (!configPath) {
+        configPath = resolve(process.cwd(), 'config.json');
+    }
+
     const fileContents = await readFile(configPath, 'utf-8');
     return JSON.parse(fileContents);
   } catch (error) {


### PR DESCRIPTION
When providing environment variables for mcp server configuration, only last one is used.

Reuce function should return whole aggreagted object. 